### PR TITLE
feat(api): configure API routes and documentation using Django Rest Framework and drf-spectacular

### DIFF
--- a/emia_ecommerce/settings/base_settings.py
+++ b/emia_ecommerce/settings/base_settings.py
@@ -38,8 +38,9 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     # External apps
     'rest_framework',
+    'drf_spectacular',
     # Internal apps
-    'emia_ecommerce.product'
+    'emia_ecommerce.product',
 ]
 
 MIDDLEWARE = [
@@ -115,4 +116,8 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-REST_FRAMEWORK = {}
+REST_FRAMEWORK = {'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema'}
+
+SPETAULAR_SETTINGS = {
+    'TITLE': 'Emia DRF Ecommerce API'
+                      }

--- a/emia_ecommerce/urls.py
+++ b/emia_ecommerce/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from emia_ecommerce.product import views 
 
@@ -8,5 +9,21 @@ router = DefaultRouter()
 router.register(r"category", views.CategoryViewSet)
 
 urlpatterns = [
-    path('admin/', admin.site.urls), path('api/', include(router.urls)),
+    path('admin/', admin.site.urls), 
+    path('api/', include(router.urls)),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/docs/', SpectacularSwaggerView.as_view(url_name='schema')),
 ]
+
+
+feat(api): configure API routes and documentation using Django Rest Framework and drf-spectacular
+
+This commit sets up API routes for the 'Category' model using Django Rest Framework's DefaultRouter. Additionally, it integrates drf-spectacular to generate API schemas and documentation endpoints.
+
+Summary of Changes:
+- Configured a DefaultRouter for 'Category' views in the 'product' app.
+- Defined API routes under '/api/' to include CRUD operations for 'Category' instances.
+- Added 'SpectacularAPIView' and 'SpectacularSwaggerView' for API schema generation and interactive documentation.
+- Enhanced the project's API capabilities and documentation features.
+
+These changes improve the organization and accessibility of API endpoints while providing comprehensive documentation through drf-spectacular.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,15 @@
 asgiref==3.7.2
+attrs==23.2.0
 Django==5.0.1
 django-js-asset==2.2.0
 django-mptt==0.16.0
 djangorestframework==3.14.0
+drf-spectacular==0.27.1
 flake8==7.0.0
+inflection==0.5.1
 iniconfig==2.0.0
+jsonschema==4.21.1
+jsonschema-specifications==2023.12.1
 mccabe==0.7.0
 packaging==23.2
 pluggy==1.4.0
@@ -14,4 +19,8 @@ pytest==7.4.4
 pytest-django==4.7.0
 python-dotenv==1.0.1
 pytz==2023.3.post1
+PyYAML==6.0.1
+referencing==0.33.0
+rpds-py==0.17.1
 sqlparse==0.4.4
+uritemplate==4.1.1

--- a/schema.yml
+++ b/schema.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /api/category/:
+    get:
+      operationId: api_category_retrieve
+      description: A viewset for viewing category instances.
+      tags:
+      - api
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          description: No response body
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid


### PR DESCRIPTION
This commit sets up API routes for the 'Category' model using Django Rest Framework's DefaultRouter. Additionally, it integrates drf-spectacular to generate API schemas and documentation endpoints.

Summary of Changes:
- Configured a DefaultRouter for 'Category' views in the 'product' app.
- Defined API routes under '/api/' to include CRUD operations for 'Category' instances.
- Added 'SpectacularAPIView' and 'SpectacularSwaggerView' for API schema generation and interactive documentation.
- Enhanced the project's API capabilities and documentation features.

These changes improve the organization and accessibility of API endpoints while providing comprehensive documentation through drf-spectacular.
