### PR TITLE
feat(api): register BrandViewSet with API router in viewsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+schema.yml
+
 .DS_Store
 
 # C extensions

--- a/emia_ecommerce/product/views.py
+++ b/emia_ecommerce/product/views.py
@@ -1,9 +1,10 @@
 from django.shortcuts import render
 from rest_framework import viewsets
 from rest_framework.response import Response   
+from drf_spectacular.utils import extend_schema
 
-from .models import Category
-from .serializers import CategorySerializer
+from .models import Category, Brand
+from .serializers import CategorySerializer, BrandSerializer
 
 
 class CategoryViewSet(viewsets.ViewSet):
@@ -12,7 +13,21 @@ class CategoryViewSet(viewsets.ViewSet):
     """
     queryset = Category.objects.all()
     
+    @extend_schema(responses=CategorySerializer)
     def list(self, request):
         queryset = Category.objects.all()
         serializer = CategorySerializer(queryset, many=True)
+        return Response(serializer.data)
+    
+
+class BrandViewSet(viewsets.ViewSet):
+    """
+    A viewset for viewing category brands.   
+    """
+    queryset = Category.objects.all()
+    
+    @extend_schema(responses=BrandSerializer)
+    def list(self, request):
+        queryset = Brand.objects.all()
+        serializer = BrandSerializer(queryset, many=True)
         return Response(serializer.data)

--- a/emia_ecommerce/urls.py
+++ b/emia_ecommerce/urls.py
@@ -7,6 +7,7 @@ from emia_ecommerce.product import views
 
 router = DefaultRouter()
 router.register(r"category", views.CategoryViewSet)
+router.register(r"brand", views.BrandViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls), 
@@ -14,16 +15,3 @@ urlpatterns = [
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/schema/docs/', SpectacularSwaggerView.as_view(url_name='schema')),
 ]
-
-
-feat(api): configure API routes and documentation using Django Rest Framework and drf-spectacular
-
-This commit sets up API routes for the 'Category' model using Django Rest Framework's DefaultRouter. Additionally, it integrates drf-spectacular to generate API schemas and documentation endpoints.
-
-Summary of Changes:
-- Configured a DefaultRouter for 'Category' views in the 'product' app.
-- Defined API routes under '/api/' to include CRUD operations for 'Category' instances.
-- Added 'SpectacularAPIView' and 'SpectacularSwaggerView' for API schema generation and interactive documentation.
-- Enhanced the project's API capabilities and documentation features.
-
-These changes improve the organization and accessibility of API endpoints while providing comprehensive documentation through drf-spectacular.

--- a/schema.yml
+++ b/schema.yml
@@ -5,18 +5,202 @@ info:
 paths:
   /api/category/:
     get:
-      operationId: api_category_retrieve
+      operationId: category_list
       description: A viewset for viewing category instances.
       tags:
-      - api
+      - category
       security:
       - cookieAuth: []
       - basicAuth: []
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Category'
+          description: ''
+  /api/schema/:
+    get:
+      operationId: schema_retrieve
+      description: |-
+        OpenApi3 schema for this API. Format can be selected via content negotiation.
+
+        - YAML: application/vnd.oai.openapi
+        - JSON: application/vnd.oai.openapi+json
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - json
+          - yaml
+      - in: query
+        name: lang
+        schema:
+          type: string
+          enum:
+          - af
+          - ar
+          - ar-dz
+          - ast
+          - az
+          - be
+          - bg
+          - bn
+          - br
+          - bs
+          - ca
+          - ckb
+          - cs
+          - cy
+          - da
+          - de
+          - dsb
+          - el
+          - en
+          - en-au
+          - en-gb
+          - eo
+          - es
+          - es-ar
+          - es-co
+          - es-mx
+          - es-ni
+          - es-ve
+          - et
+          - eu
+          - fa
+          - fi
+          - fr
+          - fy
+          - ga
+          - gd
+          - gl
+          - he
+          - hi
+          - hr
+          - hsb
+          - hu
+          - hy
+          - ia
+          - id
+          - ig
+          - io
+          - is
+          - it
+          - ja
+          - ka
+          - kab
+          - kk
+          - km
+          - kn
+          - ko
+          - ky
+          - lb
+          - lt
+          - lv
+          - mk
+          - ml
+          - mn
+          - mr
+          - ms
+          - my
+          - nb
+          - ne
+          - nl
+          - nn
+          - os
+          - pa
+          - pl
+          - pt
+          - pt-br
+          - ro
+          - ru
+          - sk
+          - sl
+          - sq
+          - sr
+          - sr-latn
+          - sv
+          - sw
+          - ta
+          - te
+          - tg
+          - th
+          - tk
+          - tr
+          - tt
+          - udm
+          - ug
+          - uk
+          - ur
+          - uz
+          - vi
+          - zh-hans
+          - zh-hant
+      tags:
+      - schema
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/yaml:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/vnd.oai.openapi+json:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
 components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        lft:
+          type: integer
+          readOnly: true
+        rght:
+          type: integer
+          readOnly: true
+        tree_id:
+          type: integer
+          readOnly: true
+        level:
+          type: integer
+          readOnly: true
+        parent:
+          type: integer
+          nullable: true
+      required:
+      - id
+      - level
+      - lft
+      - name
+      - rght
+      - tree_id
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
Extend the API routing configuration by registering the newly created BrandViewSet with the Django Rest Framework router. This update ensures that the API includes CRUD operations for  brands.

Summary of Changes:
- Registered BrandViewSet with the API router in viewsets.
- Added the corresponding endpoint '/api/brand/' for brand-related operations.